### PR TITLE
Fix

### DIFF
--- a/function/air/epoch2ms.go
+++ b/function/air/epoch2ms.go
@@ -21,12 +21,12 @@ func (fnEpoch2ms) Sig() (paramTypes []data.Type, isVariadic bool) {
 }
 
 func (fnEpoch2ms) Eval(params ...interface{}) (interface{}, error) {
-	/* quick and dirty : only for realtime scenario */
+	/* quick and dirty : not for simulate future events */
 	log.Info("(fnEpoch2ms.Eval) params[0] : ", params[0])
 	epoch := int64(params[0].(int))
-	if epoch > 1000000000000000000 {
-		epoch = epoch / 1000000000
-	} else if epoch > 1000000000000 {
+	if epoch > 9000000000000000 { // must be nano second - If it's in micro sec, it's GMT: Wednesday, March 14, 2255 4:00:00 PM
+		epoch = epoch / 1000000
+	} else if epoch > 10000000000000 { // must be micro second - If it's in millisec, it's GMT: Saturday, November 20, 2286 5:46:40 PM
 		epoch = epoch / 1000
 	}
 


### PR DESCRIPTION
# Story

correct the time boundary for determining epoch timestamp unit


## Changes

1. labs-air-contrib-new/function/air/epoch2ms.go

## Tests

na.
